### PR TITLE
Updates after coding workshop meeting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: starter
 Title: A Starter Kit for New Projects
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     person(given = "Daniel D.",
            family = "Sjoberg",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,28 +25,27 @@ Imports:
     gert (>= 1.3.0),
     glue (>= 1.4.2),
     here (>= 1.0.1),
+    knitr (>= 1.33),
     purrr (>= 0.3.4),
     R.utils (>= 2.10.1),
     readr (>= 1.4.0),
     renv (>= 0.13.2),
-    rstudioapi (>= 0.13),
     rlang (>= 0.4.11),
+    rmarkdown (>= 2.9),
+    rstudioapi (>= 0.13),
     stringr (>= 1.4.0),
     tibble (>= 3.1.2),
-    usethis (>= 2.0.1),
-    withr
+    usethis (>= 2.0.1)
 Suggests: 
     covr (>= 3.5.1),
-    knitr (>= 1.33),
-    rmarkdown (>= 2.8),
     rstudio.prefs (>= 0.1.0),
     testthat (>= 3.0.0)
 VignetteBuilder: 
     knitr
+Remotes:
+    ddsjoberg/rstudio.prefs
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-Remotes:
-    ddsjoberg/rstudio.prefs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,19 +25,19 @@ Imports:
     gert (>= 1.3.0),
     glue (>= 1.4.2),
     here (>= 1.0.1),
-    knitr (>= 1.33),
     purrr (>= 0.3.4),
     R.utils (>= 2.10.1),
     readr (>= 1.4.0),
     renv (>= 0.13.2),
     rlang (>= 0.4.11),
-    rmarkdown (>= 2.9),
     rstudioapi (>= 0.13),
     stringr (>= 1.4.0),
     tibble (>= 3.1.2),
     usethis (>= 2.0.1)
 Suggests: 
     covr (>= 3.5.1),
+    knitr (>= 1.33),
+    rmarkdown (>= 2.9),
     rstudio.prefs (>= 0.1.0),
     testthat (>= 3.0.0)
 VignetteBuilder: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# starter 0.1.1
+
+* When `create_project(renv = TRUE)`, `renv::init()` has been switched to `renv::scaffold()`. This stops renv from initializing the project. The user must call `renv::hydrate()` in order to discover the packages used in the project's `*.R` and `*.Rmd` files and have them added to the `renv.lock` file.
+
+* When a user specifies an attribute to the template list called `"script_path"`, the path is sourced.
+
 # starter 0.1.0
 
 * First release

--- a/R/create_project.R
+++ b/R/create_project.R
@@ -144,7 +144,7 @@ evaluate_project_template <- function(template, path, git, renv) {
   check_template_structure(selected_template)
 
   # return evaluated template --------------------------------------------------
-    selected_template
+  selected_template
 }
 
 # check the structure of the passed template object
@@ -157,7 +157,7 @@ check_template_structure <- function(selected_template) {
   if (!is.null(attr(selected_template, "script_path")) &&
       !fs::file_exists(attr(selected_template, "script_path"))) {
     paste("Template attribute 'script_path' must be a file location.") %>%
-    stop(call. = FALSE)
+      stop(call. = FALSE)
   }
 
   for (i in names(selected_template)) {
@@ -183,8 +183,8 @@ check_template_structure <- function(selected_template) {
       stop(call. = FALSE)
     # check the template file exists
     if (!fs::file_exists(selected_template[[i]][["template_filename"]]))
-        glue::glue("Template file {ui_value(selected_template[[i]][['template_filename']])} ",
-                   "does not exist.") %>%
+      glue::glue("Template file {ui_value(selected_template[[i]][['template_filename']])} ",
+                 "does not exist.") %>%
       stop(call. = FALSE)
 
   }

--- a/data-raw/project_templates.R
+++ b/data-raw/project_templates.R
@@ -20,7 +20,19 @@ default_project_template <-
         fs::path_package(package = "starter", "project_templates/default_rproj.Rproj"),
       filename = stringr::str_glue("{folder_name}.Rproj"),
       glue = FALSE
-    )
+    ),
+    # only add Rprofile if renv was used
+    rprofile =
+      switch(
+        renv,
+        list(
+          template_filename =
+            fs::path_package(package = "starter",
+                             "project_templates/default_rprofile.R"),
+          filename = stringr::str_glue(".Rprofile"),
+          glue = TRUE
+        )
+      )
   ))
 attr(default_project_template, "label") <- "Default Project Template"
 

--- a/inst/project_templates/default_rprofile.R
+++ b/inst/project_templates/default_rprofile.R
@@ -1,0 +1,6 @@
+
+# if renv project & bare, print message to record pkgs in R and Rmd scripts
+if (file.exists("renv.lock") &&
+    length(setdiff(installed.packages(.libPaths()[1])[, 1], "renv")) == 0L) {
+  message("* Discover packages with `renv::install('rmarkdown'); renv::hydrate()`")
+}

--- a/vignettes/create_project.Rmd
+++ b/vignettes/create_project.Rmd
@@ -178,6 +178,13 @@ gitignore = list(
 ))
 ```
 
+You may also `source()` an R script by adding the path to the file as a template attribute.
+The script will be sourced after project template has been placed.
+
+```r
+attr(my_template, "script_path") <- "<path to file>"
+```
+
 There is one last step---give your template a label.
 The label will be displayed each time the template is used in either `create_project()` or `use_project_file()`.
 


### PR DESCRIPTION
* When `create_project(renv = TRUE)`, `renv::init()` has been switched to `renv::scaffold()`. This stops renv from initializing the project. The user must call `renv::hydrate()` in order to discover the packages used in the project's `*.R` and `*.Rmd` files and have them added to the `renv.lock` file.

* When a user specifies an attribute to the template list called `"script_path"`, the path is sourced.

closes #3 