### PR TITLE
adding ability to override function args with a template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: starter
 Title: Starter Kit for New Projects
-Version: 0.1.6.9002
+Version: 0.1.6.9003
 Authors@R: 
     person(given = "Daniel D.",
            family = "Sjoberg",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # starter (development version)
 
+* Allowing users to use their template to override function arguments in `create_project()`. This way, if the user never uses git, for example, this can be communicated in the template, rather than needing to remember to change the function argument every time.
+
 * Added `create_project(symlink=)` argument indicating whether or not to place a symbolic link to the folder indicated in `create_project(path_data=).`
 
 * Updated `.Rprofile` start-up message for new repositories include the `renv::snapshot()` step.

--- a/R/create_project.R
+++ b/R/create_project.R
@@ -47,6 +47,21 @@
 create_project <- function(path, path_data = NULL, template = "default",
                            git = TRUE, renv = TRUE, overwrite = NA,
                            open = interactive()) {
+  # check if template has function arg override --------------------------------
+  if (!is.null(template) && rlang::is_list(template) && !is.null(attr(template, "arg_override"))) {
+    override_arg_list <- attr(template, "arg_override")
+
+    # print note about args being set
+    override_arg_list %>%
+      purrr::iwalk(
+        function(arg, name) {
+          if (!identical(arg, eval(parse(text = name))))
+            stringr::str_glue("Argument Override, {name}: {eval(parse(text = name))} --> {arg}")
+        }
+      )
+    list2env(override_arg_list, envir = rlang::current_env())
+  }
+
   # ask user -------------------------------------------------------------------
   if (is.na(git))
     git <- ifelse(!interactive(), TRUE, ui_yeah("Initialise Git repo?",

--- a/R/create_project.R
+++ b/R/create_project.R
@@ -56,8 +56,7 @@ create_project <- function(path, path_data = NULL, template = "default",
       purrr::iwalk(
         function(arg, name) {
           if (!identical(arg, eval(parse(text = name))))
-            stringr::str_glue("Argument Override, {name}: {eval(parse(text = name))} --> {arg}") %>%
-            cat("\n")
+            ui_done("Using template argument override {ui_code(paste(name, arg, sep = ' = '))}")
         }
       )
     list2env(override_arg_list, envir = rlang::current_env())

--- a/R/create_project.R
+++ b/R/create_project.R
@@ -48,7 +48,7 @@ create_project <- function(path, path_data = NULL, template = "default",
                            git = TRUE, renv = TRUE, overwrite = NA,
                            open = interactive()) {
   # check if template has function arg override --------------------------------
-  if (!is.null(template) && rlang::is_list(template) && !is.null(attr(template, "arg_override"))) {
+  if (!is.null(template) && !is.null(attr(template, "arg_override"))) {
     override_arg_list <- attr(template, "arg_override")
 
     # print note about args being set
@@ -56,7 +56,8 @@ create_project <- function(path, path_data = NULL, template = "default",
       purrr::iwalk(
         function(arg, name) {
           if (!identical(arg, eval(parse(text = name))))
-            stringr::str_glue("Argument Override, {name}: {eval(parse(text = name))} --> {arg}")
+            stringr::str_glue("Argument Override, {name}: {eval(parse(text = name))} --> {arg}") %>%
+            cat("\n")
         }
       )
     list2env(override_arg_list, envir = rlang::current_env())

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,13 +53,12 @@ create_project(
 Check out examples of starter templates currently being used.
 
 ```r
-devtools::install_github("ddsjoberg/hotfun")
+devtools::install_github("ddsjoberg/bstfun")
 create_project(
   path = fs::path(tempdir(), "My Project Folder"),
-  template = hotfun::project_template
+  template = bstfun::project_templates[["hot"]]
 )
 
-devtools::install_github("ddsjoberg/bstfun")
 create_project(
   path = fs::path(tempdir(), "My Project Folder"),
   template = bstfun::project_templates[["default"]]

--- a/README.md
+++ b/README.md
@@ -40,12 +40,11 @@ create_project(
   open = FALSE # don't open project in new RStudio session
 )
 #> v Using 'Default Project Template' template
-#> v Writing folder 'C:/Users/sjobergd/AppData/Local/Temp/Rtmp27btX5/My Project Folder/'
+#> v Writing folder 'C:/Users/SjobergD/AppData/Local/Temp/RtmpeCEIQJ/My Project Folder/'
 #> v Writing files 'README.md', '.gitignore', 'My Project Folder.Rproj', '.Rprofile'
 #> v Initialising Git repo
-#> v Setting active project to '<no active project>'
 #> v Initialising renv project
-#> * renv infrastructure has been generated for project "C:/Users/sjobergd/AppData/Local/Temp/Rtmp27btX5/My Project Folder".
+#> * renv infrastructure has been generated for project "C:/Users/SjobergD/AppData/Local/Temp/RtmpeCEIQJ/My Project Folder".
 ```
 
 ## Example Templates
@@ -53,13 +52,12 @@ create_project(
 Check out examples of starter templates currently being used.
 
 ``` r
-devtools::install_github("ddsjoberg/hotfun")
+devtools::install_github("ddsjoberg/bstfun")
 create_project(
   path = fs::path(tempdir(), "My Project Folder"),
-  template = hotfun::project_template
+  template = bstfun::project_templates[["hot"]]
 )
 
-devtools::install_github("ddsjoberg/bstfun")
 create_project(
   path = fs::path(tempdir(), "My Project Folder"),
   template = bstfun::project_templates[["default"]]

--- a/man/starter-package.Rd
+++ b/man/starter-package.Rd
@@ -6,12 +6,7 @@
 \alias{starter-package}
 \title{starter: Starter Kit for New Projects}
 \description{
-Get started with new projects by dropping a skeleton of a new
-    project into a new or existing directory, initialise git repositories,
-    and create reproducible environments with the 'renv' package. The
-    package allows for dynamically named files, folders, file content, as
-    well as the functionality to drop individual template files into
-    existing projects.
+Get started with new projects by dropping a skeleton of a new project into a new or existing directory, initialise git repositories, and create reproducible environments with the 'renv' package. The package allows for dynamically named files, folders, file content, as well as the functionality to drop individual template files into existing projects.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/test-create_project.R
+++ b/tests/testthat/test-create_project.R
@@ -11,6 +11,18 @@ test_that("create_project() works", {
     NA
   )
 
+  override_template <- project_templates[["default"]]
+  attr(override_template, "arg_override") <- list(git = FALSE, renv = FALSE)
+  expect_error(
+    create_project(
+      path = proj_dir,
+      template = override_template,
+      overwrite = TRUE,
+      open = FALSE # don't open project in new RStudio session
+    ),
+    NA
+  )
+
   # save existing wd
   oldwd <- getwd()
   setwd(proj_dir)

--- a/vignettes/create_project.Rmd
+++ b/vignettes/create_project.Rmd
@@ -187,6 +187,11 @@ attr(my_template, "script_path") <- "<path to file>"
 
 Wrap the path to the script in an expression if you need to delay the evaluation of the path string.
 
+You can also override the `create_project()` arguments by adding an attribute with a named list of the argument values you'd like the template to use.
+For example, if you always want to initialize the git repo and never use renv, attach this list `list(git = TRUE, renv = FALSE)` as an attribute called `"arg_override"`.
+For this feature to work, the template object must be an unquoted list.
+While the entire template cannot be quoted or an expression, the individual list elements can still be quoted.
+
 There is one last step---give your template a label.
 The label will be displayed each time the template is used in either `create_project()` or `use_project_file()`.
 

--- a/vignettes/create_project.Rmd
+++ b/vignettes/create_project.Rmd
@@ -189,8 +189,6 @@ Wrap the path to the script in an expression if you need to delay the evaluation
 
 You can also override the `create_project()` arguments by adding an attribute with a named list of the argument values you'd like the template to use.
 For example, if you always want to initialize the git repo and never use renv, attach this list `list(git = TRUE, renv = FALSE)` as an attribute called `"arg_override"`.
-For this feature to work, the template object must be an unquoted list.
-While the entire template cannot be quoted or an expression, the individual list elements can still be quoted.
 
 There is one last step---give your template a label.
 The label will be displayed each time the template is called in either `create_project()` or `use_project_file()`.


### PR DESCRIPTION
Allowing users to use their template to override function arguments in `create_project()`. This way, if they never use git, for example, this can be communicated in the template, rather than needing to remember to change the function argument every time.

Example

```r
renv::install("ddsjoberg/bstfun")
test_template <- bstfun::project_templates[["hot"]]

attr(test_template, "arg_override") <- list(git = FALSE, renv = FALSE)

create_project(path = tempdir(), template = test_template)
#> Argument Override, git: TRUE --> FALSE
#> Argument Override, renv: TRUE --> FALSE
```

closes #14