### PR TITLE
Suggest `stringr` as needed by `starter::create_project()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Suggests:
     pkgdown (>= 1.6.1),
     readr (>= 2.0.1),
     rmarkdown (>= 2.11),
+    stringr,
     spelling (>= 2.2),
     testthat (>= 3.0.4)
 VignetteBuilder: 


### PR DESCRIPTION
Previously this soft dependency doesn't need to be explicitly declared because **rmarkdown** has been suggested, which requires **stringr** (which in turn requires **stringi**). Now the dependency is no longer guaranteed in **rmarkdown** (https://github.com/rstudio/rmarkdown/pull/2530), so **starter** has to explicitly declare the dependency, otherwise it will fail `R CMD check`:

```
── Failure ('test-create_project.R:6:3'): create_project() works ───────────────
    `create_project(...)` threw an unexpected error.
    Message: there is no package called 'stringr'
    Class:   packageNotFoundError/error/condition
    Backtrace:
         ▆
      1. ├─testthat::expect_error(...) at test-create_project.R:6:3
      2. │ └─testthat:::expect_condition_matching(...)
      3. │   └─testthat:::quasi_capture(...)
      4. │     ├─testthat (local) .capture(...)
      5. │     │ └─base::withCallingHandlers(...)
      6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
      7. └─starter::create_project(...)
      8.   └─starter:::evaluate_project_template(...)
      9.     └─base::tryCatch(...)
     10.       └─base (local) tryCatchList(expr, classes, parentenv, handlers)
     11.         └─base (local) tryCatchOne(...)
     12.           └─value[[3L]](cond)
    ── Failure ('test-create_project.R:19:3'): create_project() works ──────────────
    `create_project(...)` threw an unexpected error.
    Message: there is no package called 'stringr'
    Class:   packageNotFoundError/error/condition
    Backtrace:
         ▆
      1. ├─testthat::expect_error(...) at test-create_project.R:19:3
      2. │ └─testthat:::expect_condition_matching(...)
      3. │   └─testthat:::quasi_capture(...)
      4. │     ├─testthat (local) .capture(...)
      5. │     │ └─base::withCallingHandlers(...)
      6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
      7. └─starter::create_project(...)
      8.   └─starter:::evaluate_project_template(...)
      9.     └─base::tryCatch(...)
     10.       └─base (local) tryCatchList(expr, classes, parentenv, handlers)
     11.         └─base (local) tryCatchOne(...)
     12.           └─value[[3L]](cond)
    ── Failure ('test-create_project.R:32:3'): create_project() works ──────────────
    `create_project(...)` threw an unexpected error.
    Message: there is no package called 'stringr'
    Class:   packageNotFoundError/error/condition
    Backtrace:
         ▆
      1. ├─testthat::expect_error(...) at test-create_project.R:32:3
      2. │ └─testthat:::expect_condition_matching(...)
      3. │   └─testthat:::quasi_capture(...)
      4. │     ├─testthat (local) .capture(...)
      5. │     │ └─base::withCallingHandlers(...)
      6. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
      7. └─starter::create_project(...)
      8.   └─starter:::evaluate_project_template(...)
      9.     └─base::tryCatch(...)
     10.       └─base (local) tryCatchList(expr, classes, parentenv, handlers)
     11.         └─base (local) tryCatchOne(...)
     12.           └─value[[3L]](cond)
    ── Error ('test-create_project.R:44:3'): create_project() works ────────────────
    Error in `setwd(proj_dir)`: cannot change working directory
    Backtrace:
        ▆
     1. └─base::setwd(proj_dir) at test-create_project.R:44:3

    [ FAIL 4 | WARN 0 | SKIP 0 | PASS 10 ]
    Error: Test failures
    Execution halted
```